### PR TITLE
Bump Quaternions.jl compat?

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "Octonions"
 uuid = "d00ba074-1e29-4f5e-9fd4-d67071d6a14d"
-version = "0.1.0"
+version = "0.1.1"
 
 [deps]
 LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"
@@ -8,7 +8,7 @@ Quaternions = "94ee1d12-ae83-5a48-8b1c-48b8ff168ae0"
 Random = "9a3f8284-a2c9-5f02-9a11-845980a1fd5c"
 
 [compat]
-Quaternions = "0.5.6"
+Quaternions = "0.5.6, 0.6, 0.7"
 julia = "1"
 
 [extras]


### PR DESCRIPTION
This seems to block upgrades in packages that use both, such as LinearMaps.jl (for testing purposes). Feel free to close if that is on purpose.