### PR TITLE
Remove DEV suffix from version number

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "Octonions"
 uuid = "d00ba074-1e29-4f5e-9fd4-d67071d6a14d"
-version = "0.2.0-DEV"
+version = "0.2.0"
 
 [deps]
 LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"

--- a/src/octonion.jl
+++ b/src/octonion.jl
@@ -29,7 +29,6 @@ octo(x) = Octonion(x)
 
 real(o::Octonion) = o.s
 imag_part(o::Octonion) = (o.v1, o.v2, o.v3, o.v4, o.v5, o.v6, o.v7)
-@deprecate imag(o::Octonion) collect(imag_part(o)) false
 
 (/)(o::Octonion, x::Real) = Octonion(o.s / x, o.v1 / x, o.v2 / x, o.v3 / x, o.v4 / x, o.v5 / x, o.v6 / x, o.v7 / x)
 (*)(o::Octonion, x::Real) = Octonion(o.s * x, o.v1 * x, o.v2 * x, o.v3 * x, o.v4 * x, o.v5 * x, o.v6 * x, o.v7 * x)

--- a/test/octonion.jl
+++ b/test/octonion.jl
@@ -125,7 +125,6 @@ end
         qnorm = sign(q)
         @test real(q) === q.s
         @test_throws MethodError imag(q)
-        @test @test_deprecated(Octonions.imag(q)) == [q.v1, q.v2, q.v3, q.v4, q.v5, q.v6, q.v7]
         @test imag_part(q) === (q.v1, q.v2, q.v3, q.v4, q.v5, q.v6, q.v7)
         @test conj(q) ===
             Octonion(q.s, -q.v1, -q.v2, -q.v3, -q.v4, -q.v5, -q.v6, -q.v7)


### PR DESCRIPTION
I believe all of the recent breaking changes in Quaternions now have analogs here; the rest are non-breaking. So I've marked the version as v0.2.0 for a breaking release.