### PR TITLE
Make abs, abs_imag, inv, and / resistant to under/overflow

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "Octonions"
 uuid = "d00ba074-1e29-4f5e-9fd4-d67071d6a14d"
-version = "0.2.0"
+version = "0.2.1"
 
 [deps]
 LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"

--- a/Project.toml
+++ b/Project.toml
@@ -5,9 +5,11 @@ version = "0.2.0"
 [deps]
 LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"
 Random = "9a3f8284-a2c9-5f02-9a11-845980a1fd5c"
+RealDot = "c1ae055f-0cd5-4b69-90a6-9a35b1a98df9"
 
 [compat]
 Quaternions = "0.7"
+RealDot = "0.1"
 julia = "1"
 
 [extras]

--- a/src/Octonions.jl
+++ b/src/Octonions.jl
@@ -5,6 +5,7 @@ import Base: abs, abs2, conj, exp, inv, isreal, isfinite, isinf, iszero, isnan, 
 import Base: promote_rule, float
 import Base: rand, randn
 using Random
+using RealDot: RealDot
 
 Base.@irrational INV_SQRT_EIGHT 0.3535533905932737622004 sqrt(big(0.125))
 

--- a/src/octonion.jl
+++ b/src/octonion.jl
@@ -38,8 +38,8 @@ conj(o::Octonion) = Octonion(o.s, -o.v1, -o.v2, -o.v3, -o.v4, -o.v5, -o.v6, -o.v
 abs(o::Octonion) = sqrt(abs2(o))
 float(q::Octonion{T}) where T = convert(Octonion{float(T)}, q)
 abs_imag(o::Octonion) = sqrt((o.v4 * o.v4 + (o.v2 * o.v2 + o.v6 * o.v6)) + ((o.v1 * o.v1 + o.v5 * o.v5) + (o.v3 * o.v3 + o.v7 * o.v7))) # ordered to match abs2
-abs2(o::Octonion) = ((o.s * o.s + o.v4 * o.v4) + (o.v2 * o.v2 + o.v6 * o.v6)) + ((o.v1 * o.v1  + o.v5 * o.v5) + (o.v3 * o.v3 + o.v7 * o.v7))
 inv(o::Octonion) = conj(o) / abs2(o)
+abs2(o::Octonion) = RealDot.realdot(o, o)
 
 isreal(o::Octonion) = iszero(o.v1) & iszero(o.v2) & iszero(o.v3) & iszero(o.v4) & iszero(o.v5) & iszero(o.v6) & iszero(o.v7)
 isfinite(o::Octonion) = isfinite(real(o)) & isfinite(o.v1) & isfinite(o.v2) & isfinite(o.v3) & isfinite(o.v4) & isfinite(o.v5) & isfinite(o.v6) & isfinite(o.v7)
@@ -148,4 +148,9 @@ function randn(rng::AbstractRNG, ::Type{Octonion{T}}) where {T<:AbstractFloat}
       randn(rng, T) * INV_SQRT_EIGHT,
       randn(rng, T) * INV_SQRT_EIGHT,
   )
+end
+
+function RealDot.realdot(o::Octonion, w::Octonion)
+    return ((o.s * w.s + o.v4 * w.v4) + (o.v2 * w.v2 + o.v6 * w.v6)) +
+           ((o.v1 * w.v1 + o.v5 * w.v5) + (o.v3 * w.v3 + o.v7 * w.v7))
 end

--- a/test/octonion.jl
+++ b/test/octonion.jl
@@ -2,6 +2,7 @@ using LinearAlgebra
 using Octonions
 using Quaternions: Quaternions, Quaternion, QuaternionF64
 using Random
+using RealDot: realdot
 using Test
 
 _octo(a::Real) = octo(a)
@@ -439,5 +440,20 @@ end
             @test sign(qnorm) ≈ qnorm
         end
         @inferred(sign(octo(1:8...)))
+    end
+
+    @testset "RealDot with $T" for T in (Float32, Float64)
+        for _ in 1:10
+            q1 = randn(Octonion{T})
+            q2 = randn(Octonion{T})
+            # Check real∘dot is equal to realdot.
+            @test real(dot(q1,q2)) == @inferred(realdot(q1,q2))
+            # Check realdot is commutative.
+            @test realdot(q1,q2) == realdot(q2,q1)
+            # Check real∘dot is also commutative just in case.
+            @test real(dot(q1,q2)) == real(dot(q2,q1))
+            # Check the return type of realdot is correct.
+            @test realdot(q1,q2) isa T
+        end
     end
 end


### PR DESCRIPTION
This PR is the companion of https://github.com/JuliaGeometry/Quaternions.jl/pull/122 and fixes #4. It primarily ensures `abs`, `abs_imag`, `inv`, and `/` do not under/overflow unnecessarily, following the implementations of the corresponding functions for `Complex`. It also implements `RealDot.realdot` as in https://github.com/JuliaGeometry/Quaternions.jl/pull/119.

A quick before/after benchmark demonstrating the peformance cost of these changes.

```julia
julia> using BenchmarkTools, Octonions

julia> q, w = rand(OctonionF64, 2);
```

Before:
```julia
julia> @btime abs2($q);
  1.923 ns (0 allocations: 0 bytes)

julia> @btime abs($q);
  1.924 ns (0 allocations: 0 bytes)

julia> @btime $(Octonions.abs_imag)($q);
  1.926 ns (0 allocations: 0 bytes)

julia> @btime inv($q);
  12.884 ns (0 allocations: 0 bytes)

julia> @btime $q / $w;
  30.243 ns (0 allocations: 0 bytes)
```

After:
```julia
julia> @btime abs2($q);
  1.687 ns (0 allocations: 0 bytes)

julia> @btime abs($q);
  18.967 ns (0 allocations: 0 bytes)

julia> @btime $(Octonions.abs_imag)($q);
  16.890 ns (0 allocations: 0 bytes)

julia> @btime inv($q);
  26.269 ns (0 allocations: 0 bytes)

julia> @btime $q / $w;
  49.940 ns (0 allocations: 0 bytes)
```