### PR TITLE
Add `rng` argument to `octorand` function

### DIFF
--- a/src/octonion.jl
+++ b/src/octonion.jl
@@ -130,7 +130,7 @@ function Base.sqrt(o::Octonion)
   exp(0.5 * log(o))
 end
 
-octorand() = octo(randn(), randn(), randn(), randn(), randn(), randn(), randn(), randn())
+octorand(rng::AbstractRNG = Random.GLOBAL_RNG) = octo(randn(rng), randn(rng), randn(rng), randn(rng), randn(rng), randn(rng), randn(rng), randn(rng))
 
 function Base.rand(rng::AbstractRNG, ::Random.SamplerType{Octonion{T}}) where {T<:Real}
   Octonion{T}(rand(rng, T), rand(rng, T), rand(rng, T), rand(rng, T),


### PR DESCRIPTION
I'm not sure we really need this function, but at least it seems better to have the argument `rng`.
Note that there also be [`Quaternions.quatrand` function](https://github.com/JuliaGeometry/Quaternions.jl/blob/6cba417f4b75b309429dd0f4e7a60d5d28b259f5/src/Quaternion.jl#L328).