### PR TITLE
Improvements to random octonion generation

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "Octonions"
 uuid = "d00ba074-1e29-4f5e-9fd4-d67071d6a14d"
-version = "0.2.2"
+version = "0.2.3"
 
 [deps]
 LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"

--- a/src/Octonions.jl
+++ b/src/Octonions.jl
@@ -6,6 +6,6 @@ using RealDot: RealDot
 include("octonion.jl")
 
 export Octonion, OctonionF16, OctonionF32, OctonionF64
-export imag_part, octo, octorand
+export imag_part, octo
 
 end # module

--- a/src/Octonions.jl
+++ b/src/Octonions.jl
@@ -3,8 +3,6 @@ module Octonions
 using Random
 using RealDot: RealDot
 
-Base.@irrational INV_SQRT_EIGHT 0.3535533905932737622004 sqrt(big(0.125))
-
 include("octonion.jl")
 
 export Octonion, OctonionF16, OctonionF32, OctonionF64

--- a/src/octonion.jl
+++ b/src/octonion.jl
@@ -180,15 +180,16 @@ function Base.rand(rng::AbstractRNG, ::Random.SamplerType{Octonion{T}}) where {T
 end
 
 function Base.randn(rng::AbstractRNG, ::Type{Octonion{T}}) where {T<:AbstractFloat}
+  scale = inv(sqrt(T(8)))
   Octonion{T}(
-      randn(rng, T) * INV_SQRT_EIGHT,
-      randn(rng, T) * INV_SQRT_EIGHT,
-      randn(rng, T) * INV_SQRT_EIGHT,
-      randn(rng, T) * INV_SQRT_EIGHT,
-      randn(rng, T) * INV_SQRT_EIGHT,
-      randn(rng, T) * INV_SQRT_EIGHT,
-      randn(rng, T) * INV_SQRT_EIGHT,
-      randn(rng, T) * INV_SQRT_EIGHT,
+      randn(rng, T) * scale,
+      randn(rng, T) * scale,
+      randn(rng, T) * scale,
+      randn(rng, T) * scale,
+      randn(rng, T) * scale,
+      randn(rng, T) * scale,
+      randn(rng, T) * scale,
+      randn(rng, T) * scale,
   )
 end
 

--- a/src/octonion.jl
+++ b/src/octonion.jl
@@ -172,7 +172,7 @@ function Base.sqrt(o::Octonion)
   exp(0.5 * log(o))
 end
 
-octorand(rng::AbstractRNG = Random.GLOBAL_RNG) = octo(randn(rng), randn(rng), randn(rng), randn(rng), randn(rng), randn(rng), randn(rng), randn(rng))
+Base.@deprecate octorand(rng::AbstractRNG=Random.GLOBAL_RNG) randn(rng, OctonionF64)*sqrt(8)
 
 function Base.rand(rng::AbstractRNG, ::Random.SamplerType{Octonion{T}}) where {T<:Real}
   Octonion{T}(rand(rng, T), rand(rng, T), rand(rng, T), rand(rng, T),

--- a/test/octonion.jl
+++ b/test/octonion.jl
@@ -97,6 +97,7 @@ end
 
     @testset "random generation" begin
         @testset "octorand" begin
+            @test_deprecated octorand()
             o = octorand()
             @test o isa Octonion
         end


### PR DESCRIPTION
The docstring of `Base.@irrational` warns that it should not be used outside of Base. Since we don't need it anyways, this PR stops using it.

It also deprecates `octorand([rng])` in favor of `randn([rng,] OctonionF64)`